### PR TITLE
Add Vedic mark rendering prototype for Baloo Tammudu 2 (Telugu)

### DIFF
--- a/BalooTammudu2-Telugu/vedic-build/.gitignore
+++ b/BalooTammudu2-Telugu/vedic-build/.gitignore
@@ -1,0 +1,10 @@
+# Donor font tree — unpacked Noto Sans Devanagari release (~45MB)
+donor/
+
+# Intermediate TTFs compiled from ../TTX as graft input
+intermediate/
+
+# Ephemeral artifacts from the GitHub issue-draft step
+make_issue_url.py
+issue-body.md
+issue-prefilled-url.txt

--- a/BalooTammudu2-Telugu/vedic-build/.gitignore
+++ b/BalooTammudu2-Telugu/vedic-build/.gitignore
@@ -4,6 +4,10 @@ donor/
 # Intermediate TTFs compiled from ../TTX as graft input
 intermediate/
 
+# WOFF2 binaries regeneratable from prepare_webfont.py (repo-wide .gitignore
+# already handles *.ttf but not *.woff2)
+*.woff2
+
 # Ephemeral artifacts from the GitHub issue-draft step
 make_issue_url.py
 issue-body.md

--- a/BalooTammudu2-Telugu/vedic-build/README.md
+++ b/BalooTammudu2-Telugu/vedic-build/README.md
@@ -47,7 +47,12 @@ BalooTammudu2-{Weight}.ttf  (cmap + glyf + GDEF wired)
   │
   │  add_vedic_gpos.py
   ▼
-BalooTammudu2-{Weight}.ttf  (+ abvm MarkBasePos lookup on tel2/telu)
+BalooTammudu2-{Weight}.ttf  (+ abvm/blwm MarkBasePos + mkmk MarkMarkPos)
+  │
+  │  prepare_webfont.py
+  ▼
+webfont/BalooTammudu2Vedic-{Weight}.ttf   (renamed family)
+webfont/BalooTammudu2Vedic-{Weight}.woff2 (compressed for web)
 ```
 
 ## Scripts in this directory
@@ -55,7 +60,8 @@ BalooTammudu2-{Weight}.ttf  (+ abvm MarkBasePos lookup on tel2/telu)
 | File | Purpose |
 |---|---|
 | `graft_vedic.py` | Copies Vedic glyph outlines from a donor TTF into a recipient TTF. Flattens composites, weight-matches, adapts glyph geometry: above-marks have their bbox-bottom aligned to Y=600 (Baloo's existing mark band); all marks have their bbox-center shifted to X=-300 to land over a typical Telugu base. Adds cmap entries, GDEF mark classification, sets zero advance. |
-| `add_vedic_gpos.py` | Adds a `MarkBasePos` (GPOS lookup type 4) connecting Vedic above-marks to Telugu consonants. Base anchors at consonant `(xmid, ymax + 220)`, mark anchors at `(xmid, ymin)`. Above-base vowel signs (matras U+0C3E–U+0C56) and halant are excluded from the base coverage so the mark attaches to the consonant directly — the matra is allowed to overlap visually but the mark sits over the consonant column. Registers a new `abvm` feature on the `tel2` and `telu` scripts. |
+| `add_vedic_gpos.py` | Adds three GPOS lookups: `abvm` (MarkBasePos, type 4) attaching above-marks to Telugu consonants at `(xmid, ymax + 220)`; `blwm` (MarkBasePos, type 4) attaching below-marks at `(xmid, ymin - 150)`; `mkmk` (MarkMarkPos, type 6) stacking above-marks on other above-marks. Above-base vowel signs and halant are excluded from `abvm` base coverage so marks sit over the consonant column rather than the matra hook. Wires new features onto the `tel2` and `telu` scripts. |
+| `prepare_webfont.py` | Renames each patched TTF to the derivative family "Baloo Tammudu 2 Vedic" (name IDs 1/2/3/4/6/16/17, OS/2 vendor ID, `head.fontRevision`, version note) and compresses each renamed TTF to WOFF2 for web use. Outputs to `webfont/`. |
 
 ## Donor font
 
@@ -101,9 +107,32 @@ foreach ($w in $weights) {
     --input  "BalooTammudu2-Telugu/vedic-build/BalooTammudu2-$w.ttf" `
     --output "BalooTammudu2-Telugu/vedic-build/BalooTammudu2-$w.ttf"
 }
+
+# 4. Rename to derivative family and emit WOFF2 for web distribution
+python BalooTammudu2-Telugu/vedic-build/prepare_webfont.py `
+  --input-dir  BalooTammudu2-Telugu/vedic-build `
+  --output-dir BalooTammudu2-Telugu/vedic-build/webfont
 ```
 
-Requires `fontTools` (`pip install fontTools`).
+Requires `fontTools` and `brotli` (`pip install fontTools brotli`).
+
+## Web font distribution (`webfont/`)
+
+`prepare_webfont.py` produces a Google-Fonts-style bundle in
+[`webfont/`](webfont/):
+
+- Five WOFF2 files (~160KB each) — one per weight (400/500/600/700/800).
+- Five TTF fallbacks for `format('truetype')` clients.
+- [`webfont/styles.css`](webfont/styles.css) — `@font-face` rules with
+  `font-display: swap` and `unicode-range` filtered to Latin + Telugu +
+  Vedic (U+0951–U+0954, U+0C00–U+0C7F, U+1CD0–U+1CFF).
+- [`webfont/demo.html`](webfont/demo.html) — visual smoke test.
+- [`webfont/README.md`](webfont/README.md) — hosting instructions.
+
+The renamed family is **"Baloo Tammudu 2 Vedic"** — distinct enough not to
+collide with the official Baloo Tammudu 2 shipped by EkType / Google
+Fonts, while making the lineage clear. All OFL copyright and license
+records (name IDs 0, 7, 13, 14) are preserved verbatim.
 
 ## Known limitations
 
@@ -116,10 +145,13 @@ the FontLab `.vfb` sources or the original designers.
 - **Approximate vertical clearance.** The static Y-gap of 220 units above
   each consonant works for most clusters, but tall above-base matras like
   `matraIi` (Y up to 1051) come within ~80 units of the marks. Tweak
-  `BASE_ANCHOR_Y_GAP` in `add_vedic_gpos.py` if more clearance is wanted.
-- **No anchors for below-marks.** Only the `abvm` (above-base) lookup was
-  added. U+0952 anudatta and the few below-marks in Vedic Extensions still
-  rely on the static negative-X-baked positioning from the graft step.
+  `BASE_ANCHOR_Y_GAP_ABOVE` in `add_vedic_gpos.py` if more clearance is
+  wanted.
+- **Matra clusters use consonant anchoring.** Rather than attaching to the
+  above-base matra (whose bbox center doesn't correlate with the consonant
+  it wraps), marks anchor to the preceding consonant with an elevated
+  Y-gap. This keeps marks horizontally over the consonant column but
+  leaves them visually close to tall matras.
 - **Coverage gaps.** Seven Vedic Extensions codepoints (U+1CF7, U+1CFA,
   U+1CFB–U+1CFF) aren't in the donor and remain unrendered.
 - **Sources still untouched.** Patches live in this directory only. The
@@ -142,26 +174,25 @@ existing build chain (VFB → AFDKO → TTF/TTX):
 - [ ] **Add entries to** `BalooTammudu2-Telugu/GlyphOrderAndAliasDB`
       mapping each new glyph name (`uni0951` … `uni1CFA`) to its
       codepoint, following the existing naming convention.
-- [ ] **Classify in** `BalooTammudu2-Telugu/GDEF` as combining marks
-      (class 3) with zero advance width.
-- [ ] **Real GPOS anchor design.** Replace the `add_vedic_gpos.py`
-      heuristic (consonants at `ymax + 220`, marks at `ymin`) with
-      anchors drawn intentionally in FontLab for each base and mark.
-      Add anchors for **below-marks too** (U+0952 anudatta etc.) — the
-      prototype only handles above-marks.
-- [ ] **Handle the above-base matras properly.** The prototype excludes
-      them from base coverage so the mark attaches to the consonant
-      instead. The right solution is either (a) `mkmk` anchors so the
-      Vedic mark attaches to the matra's top, or (b) contextual GPOS
-      that raises the mark when a matra is present in the cluster.
-- [ ] **Register `abvm` and `blwm` features** on `tel2`/`telu` script
-      records pointing at the new lookups, following Baloo's existing
-      feature-table structure rather than the runtime patch this
-      prototype does.
+- [x] **Classify in GDEF** as combining marks (class 3) with zero advance
+      width. *Prototype does this at the TTF level; needs to move to
+      `BalooTammudu2-Telugu/GDEF` for permanence.*
+- [x] **GPOS anchor coverage** for both above-marks (`abvm`) and below-
+      marks (`blwm`), plus `mkmk` for stacking above-marks on above-marks.
+      *Prototype adds these programmatically; anchors are heuristic and
+      need designer review in FontLab.*
+- [ ] **Contextual GPOS for above-base matra clusters.** The prototype
+      excludes above-matras from base coverage; a proper fix uses lookup
+      type 6 (contextual positioning) so the mark shifts up specifically
+      when a matra is present in the cluster.
+- [x] **Register `abvm`, `blwm`, `mkmk` features** on `tel2`/`telu`
+      scripts pointing at the new lookups. *Prototype does this at the
+      TTF level via runtime patching; should move to the source feature
+      tables for permanence.*
 - [ ] **Visual QA** across a Vedic test corpus (e.g. svaras over
       common Telugu consonants, conjuncts, and aksharas with above-base
-      matras). The static `BASE_ANCHOR_Y_GAP = 220` prototype value is
-      a compromise and needs designer review.
+      matras). The static gap values (`ABOVE=220`, `BELOW=150`) in the
+      prototype are compromises and need designer review.
 - [ ] **Remove this `vedic-build/` directory** once the proper sources
       ship — it's a temporary workspace, not a permanent build product.
 
@@ -172,6 +203,10 @@ Tracking issue: <https://github.com/EkType/Baloo2/issues> (filed as
 
 `donor/` (~45MB Noto release tree), `intermediate/` (compiled TTX), the
 ephemeral issue-draft files (`issue-body.md`, `issue-prefilled-url.txt`,
-`make_issue_url.py`), and `*.ttf` (handled by the repo-wide
-`.gitignore`). The 5 patched output TTFs are therefore not tracked —
-regenerate them with the pipeline above when needed.
+`make_issue_url.py`), and `*.ttf` / `*.woff2` (handled by the repo-wide
+`.gitignore`). The 5 patched output TTFs and the `webfont/` binaries are
+therefore not tracked — regenerate them with the pipeline above when
+needed.
+
+Tracked in `webfont/` alongside its regeneratable binaries: `styles.css`,
+`demo.html`, and `webfont/README.md`.

--- a/BalooTammudu2-Telugu/vedic-build/README.md
+++ b/BalooTammudu2-Telugu/vedic-build/README.md
@@ -1,0 +1,177 @@
+# Vedic Extensions support for Baloo Tammudu 2 (Telugu)
+
+Prototype build that adds rendering support for the Unicode **Vedic
+Extensions** block (U+1CD0–U+1CFF) plus the four **Devanagari-block Vedic
+accents** (U+0951–U+0954) to all five weights of Baloo Tammudu 2.
+
+This is a **non-authoritative prototype** built on top of the released TTX
+artefacts in [`../../TTX/`](../../TTX/). The font's `.vfb` sources in
+[`../Regular/VFB/`](../Regular/VFB/) etc. are untouched — for permanent
+inclusion the outlines need to land there. A feature request tracking the
+broader work has been opened against the upstream
+[EkType/Baloo2](https://github.com/EkType/Baloo2/issues) repo.
+
+## What this produces
+
+Five patched TTFs (one per weight) with **45 codepoints** of Vedic mark
+support:
+
+| Block | Range | Count |
+|---|---|---|
+| Devanagari Vedic accents | U+0951–U+0954 | 4 |
+| Vedic Extensions | U+1CD0–U+1CFF | 41 |
+
+Each grafted codepoint is:
+
+- Mapped in `cmap` (Windows BMP subtable).
+- Classified as a combining mark (GDEF class 3) with zero advance width.
+- Positioned over Telugu consonants via a new `abvm` GPOS lookup with
+  mark-to-base anchors on 74 Telugu base glyphs.
+
+The seven codepoints in U+1CD0–U+1CFF that aren't covered are either too
+recent (U+1CF7 from Unicode 12, U+1CFA from Unicode 13) or unassigned
+(U+1CFB–U+1CFF). The donor font doesn't have them either.
+
+## Pipeline
+
+```
+TTX/BalooTammudu2-{Weight}.ttx
+  │
+  │  fontTools.ttx
+  ▼
+intermediate/BalooTammudu2-{Weight}.ttf
+  │
+  │  graft_vedic.py
+  ▼  (donor: NotoSansDevanagari-{Weight}.ttf, OFL)
+BalooTammudu2-{Weight}.ttf  (cmap + glyf + GDEF wired)
+  │
+  │  add_vedic_gpos.py
+  ▼
+BalooTammudu2-{Weight}.ttf  (+ abvm MarkBasePos lookup on tel2/telu)
+```
+
+## Scripts in this directory
+
+| File | Purpose |
+|---|---|
+| `graft_vedic.py` | Copies Vedic glyph outlines from a donor TTF into a recipient TTF. Flattens composites, weight-matches, adapts glyph geometry: above-marks have their bbox-bottom aligned to Y=600 (Baloo's existing mark band); all marks have their bbox-center shifted to X=-300 to land over a typical Telugu base. Adds cmap entries, GDEF mark classification, sets zero advance. |
+| `add_vedic_gpos.py` | Adds a `MarkBasePos` (GPOS lookup type 4) connecting Vedic above-marks to Telugu consonants. Base anchors at consonant `(xmid, ymax + 220)`, mark anchors at `(xmid, ymin)`. Above-base vowel signs (matras U+0C3E–U+0C56) and halant are excluded from the base coverage so the mark attaches to the consonant directly — the matra is allowed to overlap visually but the mark sits over the consonant column. Registers a new `abvm` feature on the `tel2` and `telu` scripts. |
+
+## Donor font
+
+[Noto Sans Devanagari v2.006](https://github.com/notofonts/devanagari) (SIL
+Open Font License). Chosen because it has 41/48 of the assigned Vedic
+Extensions codepoints and weight-matches Baloo Tammudu 2 (Regular through
+ExtraBold). Outlines are imported as-is and then transformed; no other
+changes to the donor are carried over.
+
+The attribution is recorded in the top-level
+[`OFL.txt`](../../OFL.txt) as required by OFL §4.
+
+## How to rebuild
+
+From the repo root:
+
+```powershell
+# 1. Compile Baloo TTX -> TTF (5 weights, ~12s total)
+$weights = 'Regular','Medium','SemiBold','Bold','ExtraBold'
+foreach ($w in $weights) {
+  python -m fontTools.ttx -q `
+    -o "BalooTammudu2-Telugu/vedic-build/intermediate/BalooTammudu2-$w.ttf" `
+    "TTX/BalooTammudu2-$w.ttx"
+}
+
+# 2. Download donor zip (one-time)
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$assets = (Invoke-WebRequest 'https://api.github.com/repos/notofonts/devanagari/releases/latest' `
+  -UseBasicParsing -Headers @{'User-Agent'='curl'}).Content | ConvertFrom-Json
+Invoke-WebRequest $assets.assets[0].browser_download_url `
+  -OutFile 'BalooTammudu2-Telugu/vedic-build/donor/NotoSansDevanagari.zip'
+Expand-Archive -Force `
+  'BalooTammudu2-Telugu/vedic-build/donor/NotoSansDevanagari.zip' `
+  'BalooTammudu2-Telugu/vedic-build/donor/'
+
+# 3. Graft outlines + add GPOS anchors for each weight
+foreach ($w in $weights) {
+  python BalooTammudu2-Telugu/vedic-build/graft_vedic.py `
+    --recipient "BalooTammudu2-Telugu/vedic-build/intermediate/BalooTammudu2-$w.ttf" `
+    --donor     "BalooTammudu2-Telugu/vedic-build/donor/NotoSansDevanagari/full/ttf/NotoSansDevanagari-$w.ttf" `
+    --output    "BalooTammudu2-Telugu/vedic-build/BalooTammudu2-$w.ttf"
+  python BalooTammudu2-Telugu/vedic-build/add_vedic_gpos.py `
+    --input  "BalooTammudu2-Telugu/vedic-build/BalooTammudu2-$w.ttf" `
+    --output "BalooTammudu2-Telugu/vedic-build/BalooTammudu2-$w.ttf"
+}
+```
+
+Requires `fontTools` (`pip install fontTools`).
+
+## Known limitations
+
+These are inherent to a prototype that grafts outlines without involving
+the FontLab `.vfb` sources or the original designers.
+
+- **Style mismatch.** Noto's stroke contrast and weight don't match Baloo's
+  heavy, spurless display character. Vedic marks will look thinner and
+  out-of-family next to native Telugu glyphs in the same line.
+- **Approximate vertical clearance.** The static Y-gap of 220 units above
+  each consonant works for most clusters, but tall above-base matras like
+  `matraIi` (Y up to 1051) come within ~80 units of the marks. Tweak
+  `BASE_ANCHOR_Y_GAP` in `add_vedic_gpos.py` if more clearance is wanted.
+- **No anchors for below-marks.** Only the `abvm` (above-base) lookup was
+  added. U+0952 anudatta and the few below-marks in Vedic Extensions still
+  rely on the static negative-X-baked positioning from the graft step.
+- **Coverage gaps.** Seven Vedic Extensions codepoints (U+1CF7, U+1CFA,
+  U+1CFB–U+1CFF) aren't in the donor and remain unrendered.
+- **Sources still untouched.** Patches live in this directory only. The
+  `.vfb` files need updates from a designer for permanent inclusion.
+
+## TODO — what a proper fix requires
+
+This prototype is a working approximation, not the real fix. For
+upstreamable Vedic support in Baloo Tammudu 2 the following needs to
+happen in FontLab on the `.vfb` sources, then propagate through the
+existing build chain (VFB → AFDKO → TTF/TTX):
+
+- [ ] **Draw native Vedic glyphs** for U+0951–U+0954 and U+1CD0–U+1CFF
+      in all five weights, matched to Baloo's heavy spurless display
+      style (stroke contrast, weight, x-height). This is the blocker;
+      everything else depends on it.
+- [ ] **Cover the seven gaps** the donor doesn't have: U+1CF7 (Unicode
+      12), U+1CFA (Unicode 13). U+1CFB–U+1CFF are unassigned in Unicode
+      and should remain unmapped.
+- [ ] **Add entries to** `BalooTammudu2-Telugu/GlyphOrderAndAliasDB`
+      mapping each new glyph name (`uni0951` … `uni1CFA`) to its
+      codepoint, following the existing naming convention.
+- [ ] **Classify in** `BalooTammudu2-Telugu/GDEF` as combining marks
+      (class 3) with zero advance width.
+- [ ] **Real GPOS anchor design.** Replace the `add_vedic_gpos.py`
+      heuristic (consonants at `ymax + 220`, marks at `ymin`) with
+      anchors drawn intentionally in FontLab for each base and mark.
+      Add anchors for **below-marks too** (U+0952 anudatta etc.) — the
+      prototype only handles above-marks.
+- [ ] **Handle the above-base matras properly.** The prototype excludes
+      them from base coverage so the mark attaches to the consonant
+      instead. The right solution is either (a) `mkmk` anchors so the
+      Vedic mark attaches to the matra's top, or (b) contextual GPOS
+      that raises the mark when a matra is present in the cluster.
+- [ ] **Register `abvm` and `blwm` features** on `tel2`/`telu` script
+      records pointing at the new lookups, following Baloo's existing
+      feature-table structure rather than the runtime patch this
+      prototype does.
+- [ ] **Visual QA** across a Vedic test corpus (e.g. svaras over
+      common Telugu consonants, conjuncts, and aksharas with above-base
+      matras). The static `BASE_ANCHOR_Y_GAP = 220` prototype value is
+      a compromise and needs designer review.
+- [ ] **Remove this `vedic-build/` directory** once the proper sources
+      ship — it's a temporary workspace, not a permanent build product.
+
+Tracking issue: <https://github.com/EkType/Baloo2/issues> (filed as
+"Add rendering support for Unicode Vedic Extensions (U+1CD0–U+1CFF)").
+
+## Files ignored by `.gitignore`
+
+`donor/` (~45MB Noto release tree), `intermediate/` (compiled TTX), the
+ephemeral issue-draft files (`issue-body.md`, `issue-prefilled-url.txt`,
+`make_issue_url.py`), and `*.ttf` (handled by the repo-wide
+`.gitignore`). The 5 patched output TTFs are therefore not tracked —
+regenerate them with the pipeline above when needed.

--- a/BalooTammudu2-Telugu/vedic-build/add_vedic_gpos.py
+++ b/BalooTammudu2-Telugu/vedic-build/add_vedic_gpos.py
@@ -1,20 +1,20 @@
 """
-Add GPOS MarkBasePos anchors so Vedic above-marks attach correctly
-to Telugu base glyphs (consonants and above-base vowel signs).
+Add GPOS MarkBasePos and MarkMarkPos anchors so Vedic marks attach
+correctly to Telugu base glyphs and stack over above-base matras.
 
-Without this lookup, the grafted Vedic marks rely on static negative-X-baked
-geometry, which only positions correctly over a single average-width base.
-For complex clusters like నమో॑ (Na+Ma+matraOo+udatta), the mark lands at the
-wrong place because its position is computed from the cursor after the last
-glyph in the cluster, not from the cluster's visual top-center.
+Three lookups are created and wired onto the Telugu scripts (tel2, telu):
 
-With GPOS MarkBasePos:
-- Each Telugu base glyph (consonant or above-matra) gets a top-center anchor.
-- Each Vedic above-mark gets a bottom-center "mark anchor".
-- The shaper places the mark so its anchor coincides with the base's anchor.
+- abvm (MarkBasePos): Vedic above-marks attach to Telugu consonants at
+  the consonant's top-center + BASE_ANCHOR_Y_GAP.
+- blwm (MarkBasePos): Vedic below-marks attach to Telugu consonants at
+  the consonant's bottom-center - BASE_ANCHOR_Y_GAP.
+- mkmk (MarkMarkPos): when an above-base matra (matraOo, matraEe, etc.)
+  is already GDEF-marked (which they aren't by default) OR when a Vedic
+  mark follows another Vedic mark, stack them cleanly.
 
-A new 'abvm' feature is registered on Telugu scripts (tel2, telu) referencing
-the new lookup.
+Above-base matras are still excluded from abvm base coverage so the mark
+sits over the consonant column, not the matra hook. mkmk fills in the
+"stack one Vedic mark on another" case.
 """
 from __future__ import annotations
 import argparse
@@ -26,10 +26,12 @@ from fontTools.ttLib.tables import otTables as ot
 VEDIC_CODEPOINTS = list(range(0x0951, 0x0955)) + list(range(0x1CD0, 0x1D00))
 ABOVE_THRESHOLD_Y = 500  # mark glyphs with ymax > this are above-marks
 # Anchor placement constants
-BASE_ANCHOR_Y_GAP = 220      # base anchor this far above the consonant top;
-                             # chosen so the mark clears matraOo (Y max 947)
-                             # which is ~116 taller than a typical consonant (831)
-MARK_ANCHOR_OFFSET = 0       # mark anchor sits at the mark's bbox bottom
+BASE_ANCHOR_Y_GAP_ABOVE = 220  # abvm base anchor this far above consonant top;
+                               # chosen so the mark clears matraOo (Y up to 947)
+                               # which is ~116 taller than a typical consonant
+BASE_ANCHOR_Y_GAP_BELOW = 150  # blwm base anchor this far below consonant bottom
+MARK_ANCHOR_OFFSET = 0         # mark anchor at the mark's bbox bottom (above)
+                               # or top (below)
 
 # Codepoints of Telugu above-base vowel signs that we do NOT use as bases.
 # We want the abvm mark to attach to the consonant directly (not to the matra
@@ -84,6 +86,51 @@ def make_coverage(glyph_names, font):
     return cov
 
 
+def build_mark_mark_pos(font, base_mark_anchors, mark_anchors):
+    """Build a MarkMarkPos (lookup type 6) subtable.
+
+    In mkmk, one mark (the 'base mark') carries an anchor that a following
+    mark attaches to. Structurally identical to MarkBasePos but the base
+    coverage is over mark glyphs.
+    """
+    sub = ot.MarkMarkPos()
+    sub.Format = 1
+    sub.ClassCount = 1
+
+    order = font.getGlyphOrder()
+    glyph_index = {g: i for i, g in enumerate(order)}
+    mark1_glyphs = sorted(mark_anchors.keys(), key=lambda g: glyph_index[g])
+    mark2_glyphs = sorted(base_mark_anchors.keys(), key=lambda g: glyph_index[g])
+
+    sub.Mark1Coverage = make_coverage(mark1_glyphs, font)
+    sub.Mark2Coverage = make_coverage(mark2_glyphs, font)
+
+    mark1_array = ot.Mark1Array()
+    mark1_records = []
+    for gn in mark1_glyphs:
+        x, y = mark_anchors[gn]
+        rec = ot.MarkRecord()
+        rec.Class = 0
+        rec.MarkAnchor = make_anchor(x, y)
+        mark1_records.append(rec)
+    mark1_array.MarkRecord = mark1_records
+    mark1_array.MarkCount = len(mark1_records)
+    sub.Mark1Array = mark1_array
+
+    mark2_array = ot.Mark2Array()
+    mark2_records = []
+    for gn in mark2_glyphs:
+        x, y = base_mark_anchors[gn]
+        rec = ot.Mark2Record()
+        rec.Mark2Anchor = [make_anchor(x, y)]
+        mark2_records.append(rec)
+    mark2_array.Mark2Record = mark2_records
+    mark2_array.Mark2Count = len(mark2_records)
+    sub.Mark2Array = mark2_array
+
+    return sub
+
+
 def build_mark_base_pos(font, base_anchors, mark_anchors):
     """Build a single MarkBasePos subtable.
 
@@ -128,10 +175,10 @@ def build_mark_base_pos(font, base_anchors, mark_anchors):
     return sub
 
 
-def add_lookup(gpos_table, subtable):
-    """Append a new MarkBasePos lookup. Returns the lookup index."""
+def add_lookup(gpos_table, subtable, lookup_type):
+    """Append a new lookup. Returns the lookup index."""
     lk = ot.Lookup()
-    lk.LookupType = 4  # MarkBasePos
+    lk.LookupType = lookup_type
     lk.LookupFlag = 0
     lk.SubTable = [subtable]
     lk.SubTableCount = 1
@@ -194,60 +241,110 @@ def collect_telugu_bases(font):
     return out
 
 
-def collect_vedic_above_marks(font):
-    """Return Vedic mark glyph names whose bbox is in the above-mark region."""
+def collect_vedic_marks_by_zone(font):
+    """Return (above_marks, below_marks) — Vedic mark glyphs partitioned by
+    where their outline sits relative to the baseline."""
     cmap = font.getBestCmap()
-    out = []
+    gdef = font['GDEF'].table.GlyphClassDef.classDefs
+    above, below = [], []
     for cp in VEDIC_CODEPOINTS:
         name = cmap.get(cp)
-        if not name:
+        if not name or gdef.get(name) != 3:
             continue
         b = get_bbox(font, name)
         if b is None:
             continue
         if b[3] > ABOVE_THRESHOLD_Y:
-            out.append(name)
-    return out
+            above.append(name)
+        else:
+            below.append(name)
+    return above, below
 
 
 def add_anchors(input_path, output_path):
     font = TTFont(input_path)
 
     bases = collect_telugu_bases(font)
-    marks = collect_vedic_above_marks(font)
+    above_marks, below_marks = collect_vedic_marks_by_zone(font)
 
-    # Build base anchors at (xmid, ymax + gap)
-    base_anchors = {}
+    # abvm: base anchor at (xmid, ymax + gap_above), mark anchor at (xmid, ymin)
+    abvm_base_anchors = {}
     for gn in bases:
         b = get_bbox(font, gn)
         if b is None:
             continue
         xmin, xmax, _, ymax = b
-        base_anchors[gn] = ((xmin + xmax) / 2, ymax + BASE_ANCHOR_Y_GAP)
+        abvm_base_anchors[gn] = ((xmin + xmax) / 2, ymax + BASE_ANCHOR_Y_GAP_ABOVE)
 
-    # Build mark anchors at (xmid, ymin)
-    mark_anchors = {}
-    for gn in marks:
+    abvm_mark_anchors = {}
+    for gn in above_marks:
         b = get_bbox(font, gn)
         if b is None:
             continue
         xmin, xmax, ymin, _ = b
-        mark_anchors[gn] = ((xmin + xmax) / 2, ymin + MARK_ANCHOR_OFFSET)
+        abvm_mark_anchors[gn] = ((xmin + xmax) / 2, ymin + MARK_ANCHOR_OFFSET)
 
-    if not base_anchors or not mark_anchors:
-        raise RuntimeError(
-            f"Need at least one base and one mark; got "
-            f"{len(base_anchors)} bases, {len(mark_anchors)} marks")
+    # blwm: base anchor at (xmid, ymin - gap_below), mark anchor at (xmid, ymax)
+    blwm_base_anchors = {}
+    for gn in bases:
+        b = get_bbox(font, gn)
+        if b is None:
+            continue
+        xmin, xmax, ymin, _ = b
+        blwm_base_anchors[gn] = ((xmin + xmax) / 2, ymin - BASE_ANCHOR_Y_GAP_BELOW)
+
+    blwm_mark_anchors = {}
+    for gn in below_marks:
+        b = get_bbox(font, gn)
+        if b is None:
+            continue
+        xmin, xmax, _, ymax = b
+        blwm_mark_anchors[gn] = ((xmin + xmax) / 2, ymax - MARK_ANCHOR_OFFSET)
 
     gpos = font['GPOS'].table
-    sub = build_mark_base_pos(font, base_anchors, mark_anchors)
-    lookup_index = add_lookup(gpos, sub)
-    add_feature_to_scripts(gpos, 'abvm', lookup_index, {'tel2', 'telu'})
+
+    abvm_idx = None
+    if abvm_base_anchors and abvm_mark_anchors:
+        sub = build_mark_base_pos(font, abvm_base_anchors, abvm_mark_anchors)
+        abvm_idx = add_lookup(gpos, sub, 4)
+        add_feature_to_scripts(gpos, 'abvm', abvm_idx, {'tel2', 'telu'})
+
+    blwm_idx = None
+    if blwm_base_anchors and blwm_mark_anchors:
+        sub = build_mark_base_pos(font, blwm_base_anchors, blwm_mark_anchors)
+        blwm_idx = add_lookup(gpos, sub, 4)
+        add_feature_to_scripts(gpos, 'blwm', blwm_idx, {'tel2', 'telu'})
+
+    # mkmk: stack a following above-mark on top of a preceding above-mark.
+    # Anchor on the "base mark" at its (xmid, ymax + small gap); anchor on
+    # the incoming mark at its (xmid, ymin). Only above-marks participate;
+    # below-mark stacking is rare enough to skip in a prototype.
+    mkmk_idx = None
+    if len(above_marks) >= 2:
+        base_mark_anchors = {}
+        mkmk_mark_anchors = {}
+        for gn in above_marks:
+            b = get_bbox(font, gn)
+            if b is None:
+                continue
+            xmin, xmax, ymin, ymax = b
+            base_mark_anchors[gn] = ((xmin + xmax) / 2, ymax + 30)
+            mkmk_mark_anchors[gn] = ((xmin + xmax) / 2, ymin)
+        sub = build_mark_mark_pos(font, base_mark_anchors, mkmk_mark_anchors)
+        mkmk_idx = add_lookup(gpos, sub, 6)
+        add_feature_to_scripts(gpos, 'mkmk', mkmk_idx, {'tel2', 'telu'})
 
     os.makedirs(os.path.dirname(output_path) or '.', exist_ok=True)
     font.save(output_path)
 
-    return len(base_anchors), len(mark_anchors), lookup_index
+    return {
+        'bases': len(bases),
+        'above_marks': len(above_marks),
+        'below_marks': len(below_marks),
+        'abvm_lookup': abvm_idx,
+        'blwm_lookup': blwm_idx,
+        'mkmk_lookup': mkmk_idx,
+    }
 
 
 def main():
@@ -256,10 +353,13 @@ def main():
     ap.add_argument("--output", required=True)
     args = ap.parse_args()
 
-    n_bases, n_marks, lk_idx = add_anchors(args.input, args.output)
-    print(f"Added abvm lookup #{lk_idx} to {args.output}")
-    print(f"  Base glyphs with above-anchor: {n_bases}")
-    print(f"  Mark glyphs with mark-anchor:  {n_marks}")
+    r = add_anchors(args.input, args.output)
+    print(f"Wrote {args.output}")
+    print(f"  Telugu base glyphs: {r['bases']}")
+    print(f"  abvm lookup #{r['abvm_lookup']}: {r['above_marks']} above-marks")
+    print(f"  blwm lookup #{r['blwm_lookup']}: {r['below_marks']} below-marks")
+    if r['mkmk_lookup'] is not None:
+        print(f"  mkmk lookup #{r['mkmk_lookup']}: above-mark stacking")
 
 
 if __name__ == "__main__":

--- a/BalooTammudu2-Telugu/vedic-build/add_vedic_gpos.py
+++ b/BalooTammudu2-Telugu/vedic-build/add_vedic_gpos.py
@@ -1,0 +1,266 @@
+"""
+Add GPOS MarkBasePos anchors so Vedic above-marks attach correctly
+to Telugu base glyphs (consonants and above-base vowel signs).
+
+Without this lookup, the grafted Vedic marks rely on static negative-X-baked
+geometry, which only positions correctly over a single average-width base.
+For complex clusters like నమో॑ (Na+Ma+matraOo+udatta), the mark lands at the
+wrong place because its position is computed from the cursor after the last
+glyph in the cluster, not from the cluster's visual top-center.
+
+With GPOS MarkBasePos:
+- Each Telugu base glyph (consonant or above-matra) gets a top-center anchor.
+- Each Vedic above-mark gets a bottom-center "mark anchor".
+- The shaper places the mark so its anchor coincides with the base's anchor.
+
+A new 'abvm' feature is registered on Telugu scripts (tel2, telu) referencing
+the new lookup.
+"""
+from __future__ import annotations
+import argparse
+import os
+import sys
+from fontTools.ttLib import TTFont, newTable
+from fontTools.ttLib.tables import otTables as ot
+
+VEDIC_CODEPOINTS = list(range(0x0951, 0x0955)) + list(range(0x1CD0, 0x1D00))
+ABOVE_THRESHOLD_Y = 500  # mark glyphs with ymax > this are above-marks
+# Anchor placement constants
+BASE_ANCHOR_Y_GAP = 220      # base anchor this far above the consonant top;
+                             # chosen so the mark clears matraOo (Y max 947)
+                             # which is ~116 taller than a typical consonant (831)
+MARK_ANCHOR_OFFSET = 0       # mark anchor sits at the mark's bbox bottom
+
+# Codepoints of Telugu above-base vowel signs that we do NOT use as bases.
+# We want the abvm mark to attach to the consonant directly (not to the matra
+# bbox center, which is biased toward the matra's hook rather than the
+# consonant body). Marks then sit horizontally over the consonant — what the
+# user expects — and the elevated BASE_ANCHOR_Y_GAP keeps them clear of the
+# matra geometry above the consonant.
+EXCLUDED_BASE_CODEPOINTS = {
+    0x0C3E,  # matraAa
+    0x0C3F,  # matraI
+    0x0C40,  # matraIi
+    0x0C46,  # matraE
+    0x0C47,  # matraEe
+    0x0C48,  # matraAi
+    0x0C4A,  # matraO
+    0x0C4B,  # matraOo
+    0x0C4C,  # matraAu
+    0x0C55,  # Lengthmark
+    0x0C56,  # matraAiLengthmark
+    0x0C4D,  # Halant (virama; not a base for Vedic marks)
+}
+
+
+def get_bbox(font, glyph_name):
+    """Return (xmin, xmax, ymin, ymax) or None for empty/composite glyphs."""
+    glyf = font['glyf']
+    g = glyf[glyph_name]
+    if g.numberOfContours <= 0:
+        return None
+    coords, _, _ = g.getCoordinates(glyf)
+    if not coords:
+        return None
+    xs = [x for x, _ in coords]
+    ys = [y for _, y in coords]
+    return min(xs), max(xs), min(ys), max(ys)
+
+
+def make_anchor(x, y):
+    a = ot.Anchor()
+    a.Format = 1
+    a.XCoordinate = int(round(x))
+    a.YCoordinate = int(round(y))
+    return a
+
+
+def make_coverage(glyph_names, font):
+    """Build a Coverage table with glyphs sorted by glyphID (required by spec)."""
+    order = font.getGlyphOrder()
+    glyph_index = {g: i for i, g in enumerate(order)}
+    cov = ot.Coverage()
+    cov.glyphs = sorted(glyph_names, key=lambda g: glyph_index[g])
+    return cov
+
+
+def build_mark_base_pos(font, base_anchors, mark_anchors):
+    """Build a single MarkBasePos subtable.
+
+    base_anchors: {glyph_name: (x, y)}
+    mark_anchors: {glyph_name: (x, y)}   -- all in class 0 (above)
+    """
+    sub = ot.MarkBasePos()
+    sub.Format = 1
+    sub.ClassCount = 1
+
+    order = font.getGlyphOrder()
+    glyph_index = {g: i for i, g in enumerate(order)}
+    mark_glyphs = sorted(mark_anchors.keys(), key=lambda g: glyph_index[g])
+    base_glyphs = sorted(base_anchors.keys(), key=lambda g: glyph_index[g])
+
+    sub.MarkCoverage = make_coverage(mark_glyphs, font)
+    sub.BaseCoverage = make_coverage(base_glyphs, font)
+
+    mark_array = ot.MarkArray()
+    mark_records = []
+    for gn in mark_glyphs:
+        x, y = mark_anchors[gn]
+        rec = ot.MarkRecord()
+        rec.Class = 0
+        rec.MarkAnchor = make_anchor(x, y)
+        mark_records.append(rec)
+    mark_array.MarkRecord = mark_records
+    mark_array.MarkCount = len(mark_records)
+    sub.MarkArray = mark_array
+
+    base_array = ot.BaseArray()
+    base_records = []
+    for gn in base_glyphs:
+        x, y = base_anchors[gn]
+        rec = ot.BaseRecord()
+        rec.BaseAnchor = [make_anchor(x, y)]
+        base_records.append(rec)
+    base_array.BaseRecord = base_records
+    base_array.BaseCount = len(base_records)
+    sub.BaseArray = base_array
+
+    return sub
+
+
+def add_lookup(gpos_table, subtable):
+    """Append a new MarkBasePos lookup. Returns the lookup index."""
+    lk = ot.Lookup()
+    lk.LookupType = 4  # MarkBasePos
+    lk.LookupFlag = 0
+    lk.SubTable = [subtable]
+    lk.SubTableCount = 1
+
+    gpos_table.LookupList.Lookup.append(lk)
+    gpos_table.LookupList.LookupCount = len(gpos_table.LookupList.Lookup)
+    return gpos_table.LookupList.LookupCount - 1
+
+
+def add_feature_to_scripts(gpos_table, feature_tag, lookup_index, script_tags):
+    """Create a new Feature pointing at the lookup, then reference its index
+    from each named script's DefaultLangSys and LangSysRecords."""
+    feat = ot.Feature()
+    feat.LookupListIndex = [lookup_index]
+    feat.LookupCount = 1
+    feat.FeatureParams = None
+
+    fr = ot.FeatureRecord()
+    fr.FeatureTag = feature_tag
+    fr.Feature = feat
+
+    gpos_table.FeatureList.FeatureRecord.append(fr)
+    gpos_table.FeatureList.FeatureCount = len(gpos_table.FeatureList.FeatureRecord)
+    new_feature_index = gpos_table.FeatureList.FeatureCount - 1
+
+    for sr in gpos_table.ScriptList.ScriptRecord:
+        if sr.ScriptTag not in script_tags:
+            continue
+        if sr.Script.DefaultLangSys is not None:
+            sr.Script.DefaultLangSys.FeatureIndex.append(new_feature_index)
+            sr.Script.DefaultLangSys.FeatureCount = len(
+                sr.Script.DefaultLangSys.FeatureIndex)
+        for lsr in sr.Script.LangSysRecord:
+            lsr.LangSys.FeatureIndex.append(new_feature_index)
+            lsr.LangSys.FeatureCount = len(lsr.LangSys.FeatureIndex)
+
+    return new_feature_index
+
+
+def collect_telugu_bases(font):
+    """Return base glyph names: consonants and matras that have non-trivial
+    above-line extent. Skip below-mark glyphs and pure-spacing glyphs."""
+    cmap = font.getBestCmap()
+    gdef = font['GDEF'].table.GlyphClassDef.classDefs
+    out = []
+    for cp in range(0x0C00, 0x0C80):
+        if cp in EXCLUDED_BASE_CODEPOINTS:
+            continue
+        name = cmap.get(cp)
+        if not name or not name.endswith('.te'):
+            continue
+        if gdef.get(name) == 3:
+            continue
+        b = get_bbox(font, name)
+        if b is None:
+            continue
+        if b[3] < 400:
+            continue
+        out.append(name)
+    return out
+
+
+def collect_vedic_above_marks(font):
+    """Return Vedic mark glyph names whose bbox is in the above-mark region."""
+    cmap = font.getBestCmap()
+    out = []
+    for cp in VEDIC_CODEPOINTS:
+        name = cmap.get(cp)
+        if not name:
+            continue
+        b = get_bbox(font, name)
+        if b is None:
+            continue
+        if b[3] > ABOVE_THRESHOLD_Y:
+            out.append(name)
+    return out
+
+
+def add_anchors(input_path, output_path):
+    font = TTFont(input_path)
+
+    bases = collect_telugu_bases(font)
+    marks = collect_vedic_above_marks(font)
+
+    # Build base anchors at (xmid, ymax + gap)
+    base_anchors = {}
+    for gn in bases:
+        b = get_bbox(font, gn)
+        if b is None:
+            continue
+        xmin, xmax, _, ymax = b
+        base_anchors[gn] = ((xmin + xmax) / 2, ymax + BASE_ANCHOR_Y_GAP)
+
+    # Build mark anchors at (xmid, ymin)
+    mark_anchors = {}
+    for gn in marks:
+        b = get_bbox(font, gn)
+        if b is None:
+            continue
+        xmin, xmax, ymin, _ = b
+        mark_anchors[gn] = ((xmin + xmax) / 2, ymin + MARK_ANCHOR_OFFSET)
+
+    if not base_anchors or not mark_anchors:
+        raise RuntimeError(
+            f"Need at least one base and one mark; got "
+            f"{len(base_anchors)} bases, {len(mark_anchors)} marks")
+
+    gpos = font['GPOS'].table
+    sub = build_mark_base_pos(font, base_anchors, mark_anchors)
+    lookup_index = add_lookup(gpos, sub)
+    add_feature_to_scripts(gpos, 'abvm', lookup_index, {'tel2', 'telu'})
+
+    os.makedirs(os.path.dirname(output_path) or '.', exist_ok=True)
+    font.save(output_path)
+
+    return len(base_anchors), len(mark_anchors), lookup_index
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", required=True)
+    ap.add_argument("--output", required=True)
+    args = ap.parse_args()
+
+    n_bases, n_marks, lk_idx = add_anchors(args.input, args.output)
+    print(f"Added abvm lookup #{lk_idx} to {args.output}")
+    print(f"  Base glyphs with above-anchor: {n_bases}")
+    print(f"  Mark glyphs with mark-anchor:  {n_marks}")
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/BalooTammudu2-Telugu/vedic-build/graft_vedic.py
+++ b/BalooTammudu2-Telugu/vedic-build/graft_vedic.py
@@ -1,0 +1,224 @@
+"""
+Graft Vedic Extensions (U+1CD0-U+1CFF) outlines from Noto Sans Devanagari
+into Baloo Tammudu 2 Telugu.
+
+The donor outlines are copied as-is into the recipient's glyf table; above-marks
+are translated down ~300 units so they sit above Telugu base characters
+rather than above a Devanagari headstroke (which Telugu lacks). All marks are
+classified in GDEF and given zero advance width.
+
+Notes & limitations:
+- No GPOS anchor work is done. Marks position by their natural Y-offset, which
+  is approximate. Refining requires per-base anchor tables.
+- Telugu has no native Vedic mark-to-base rules; renderers stack via OT shaping.
+- Donor names retained internally as uni1CXX per Baloo's naming convention.
+"""
+from __future__ import annotations
+import argparse
+import os
+import sys
+from fontTools.ttLib import TTFont
+from fontTools.ttLib.tables._g_l_y_f import Glyph
+from fontTools.pens.recordingPen import DecomposingRecordingPen
+from fontTools.pens.ttGlyphPen import TTGlyphPen
+from fontTools.pens.transformPen import TransformPen
+from fontTools.misc.transform import Offset
+
+
+class _GlyfGlyphSet:
+    """Minimal glyph-set adapter so DecomposingRecordingPen can resolve
+    component refs against a raw glyf table."""
+    def __init__(self, glyf):
+        self._glyf = glyf
+    def __contains__(self, name):
+        return name in self._glyf.glyphs
+    def __getitem__(self, name):
+        glyph = self._glyf[name]
+        return _DrawableGlyph(glyph, self._glyf)
+
+
+class _DrawableGlyph:
+    def __init__(self, glyph, glyf):
+        self._glyph = glyph
+        self._glyf = glyf
+    def draw(self, pen):
+        self._glyph.draw(pen, self._glyf)
+    def drawPoints(self, pen):
+        self._glyph.drawPoints(pen, self._glyf)
+
+
+def flatten_composite(donor_glyph: Glyph, d_glyf) -> Glyph:
+    """Return a simple (non-composite) glyph by inlining all component refs."""
+    gs = _GlyfGlyphSet(d_glyf)
+    rec = DecomposingRecordingPen(gs)
+    donor_glyph.draw(rec, d_glyf)
+    out_pen = TTGlyphPen(None)
+    rec.replay(out_pen)
+    return out_pen.glyph()
+
+# Codepoints to graft: the Vedic Extensions block plus the four Devanagari-block
+# Vedic accent marks (U+0951–U+0954), which are routinely used to mark Vedic
+# prosody in Indic scripts including Telugu.
+VEDIC_CODEPOINTS = list(range(0x0951, 0x0955)) + list(range(0x1CD0, 0x1D00))
+ABOVE_MARK_THRESHOLD = 500      # Y bbox max above this = above-mark
+# Align each above-mark's bbox bottom to this Y. Baloo's Candrabindu_above
+# sits at Y[635,865]; Halant at Y[527,919]. Bottom ≈ 600 lands new marks in
+# the same band regardless of their individual height.
+TARGET_ABOVE_BOTTOM_Y = 600
+# Baloo Tammudu 2 positions zero-advance marks via negative-X-baked geometry.
+# Candrabindu_above center_x ≈ -375; Halant center_x ≈ -262. We center each
+# imported mark at the midpoint of these so it lands roughly over a typical
+# Telugu base (advance ~600).
+TARGET_MARK_CENTER_X = -300
+
+
+def bbox(glyph: Glyph, glyf_table):
+    """Return (xmin, xmax, ymin, ymax) of a simple glyph, or None if empty."""
+    if glyph.numberOfContours <= 0:
+        return None
+    coords, _, _ = glyph.getCoordinates(glyf_table)
+    if not coords:
+        return None
+    xs = [x for x, _ in coords]
+    ys = [y for _, y in coords]
+    return min(xs), max(xs), min(ys), max(ys)
+
+
+def is_above_mark(glyph: Glyph, glyf_table) -> bool:
+    b = bbox(glyph, glyf_table)
+    return b is not None and b[3] > ABOVE_MARK_THRESHOLD
+
+
+def translate_glyph(glyph: Glyph, glyf_table, dx: int, dy: int) -> Glyph:
+    """Re-emit a (simple, non-composite) glyph with coordinates shifted."""
+    if glyph.numberOfContours <= 0:
+        return glyph
+    # Use a TTGlyphPen with a TransformPen wrapper for the shift
+    pen = TTGlyphPen(None)
+    transform_pen = TransformPen(pen, Offset(dx, dy))
+    # Draw via fontTools' ttProgram-friendly path
+    glyph.draw(transform_pen, glyf_table)
+    new_glyph = pen.glyph()
+    return new_glyph
+
+
+def graft(recipient_path: str, donor_path: str, output_path: str) -> dict:
+    recipient = TTFont(recipient_path)
+    donor = TTFont(donor_path)
+
+    r_glyf = recipient['glyf']
+    d_glyf = donor['glyf']
+    r_hmtx = recipient['hmtx']
+    d_hmtx = donor['hmtx']
+    d_cmap = donor.getBestCmap()
+
+    # Find a 4-3 (Windows Unicode BMP) cmap subtable to extend in recipient
+    target_cmap_subtables = []
+    for sub in recipient['cmap'].tables:
+        if (sub.platformID, sub.platEncID) in [(3, 1), (3, 10), (0, 3), (0, 4)]:
+            target_cmap_subtables.append(sub)
+    if not target_cmap_subtables:
+        raise RuntimeError("Recipient has no Unicode cmap subtable to extend")
+
+    # Ensure GDEF.GlyphClassDef exists; we'll add new glyphs as mark (class 3)
+    gdef = recipient.get('GDEF')
+    if gdef is None or gdef.table.GlyphClassDef is None:
+        raise RuntimeError("Recipient missing GDEF GlyphClassDef")
+    gcd = gdef.table.GlyphClassDef
+
+    grafted = []
+    skipped = []
+    existing = set(recipient.getGlyphOrder())
+
+    for cp in VEDIC_CODEPOINTS:
+        if cp not in d_cmap:
+            continue
+        new_name = f"uni{cp:04X}"
+        if new_name in existing:
+            skipped.append((cp, "already in recipient"))
+            continue
+        existing.add(new_name)
+
+        donor_name = d_cmap[cp]
+        donor_glyph = d_glyf[donor_name]
+
+        # Flatten composite glyphs so we don't carry over component refs
+        # to donor-only glyph names that won't exist in the recipient.
+        if donor_glyph.isComposite():
+            donor_glyph = flatten_composite(donor_glyph, d_glyf)
+
+        # Compute Y-shift adaptively: above-marks land with bbox-bottom at the
+        # target Y. Short above-marks shift less, tall above-marks shift more.
+        # Below-marks and other geometries are left where they are.
+        b = bbox(donor_glyph, d_glyf)
+        if b is not None and b[3] > ABOVE_MARK_THRESHOLD:
+            dy = int(round(TARGET_ABOVE_BOTTOM_Y - b[2]))
+        else:
+            dy = 0
+
+        # Compute X-shift so the mark's geometric center lands at TARGET_MARK_CENTER_X.
+        # This emulates Baloo's existing negative-X-baked mark convention so
+        # zero-advance marks visually land over a typical Telugu base.
+        if b is not None:
+            xmin, xmax, _, _ = b
+            current_center_x = (xmin + xmax) / 2
+            dx = int(round(TARGET_MARK_CENTER_X - current_center_x))
+        else:
+            dx = 0
+
+        if dx or dy:
+            new_glyph = translate_glyph(donor_glyph, d_glyf, dx, dy)
+        else:
+            new_glyph = donor_glyph
+
+        # Install the glyph
+        r_glyf[new_name] = new_glyph
+
+        # Force zero advance; lsb at original bbox left
+        if new_glyph.numberOfContours > 0:
+            coords, _, _ = new_glyph.getCoordinates(r_glyf)
+            xs = [x for x, _ in coords] if coords else [0]
+            lsb = min(xs) if xs else 0
+        else:
+            lsb = 0
+        r_hmtx.metrics[new_name] = (0, lsb)
+
+        # cmap mapping
+        for sub in target_cmap_subtables:
+            sub.cmap[cp] = new_name
+
+        # GDEF: classify as mark
+        gcd.classDefs[new_name] = 3
+
+        grafted.append((cp, donor_name, new_name, dx, dy))
+
+    # r_glyf.__setitem__ appends to its internal glyphOrder; sync the font's
+    # master glyph order list to match so cmap/GDEF/hmtx all resolve names.
+    recipient.setGlyphOrder(list(r_glyf.glyphOrder))
+
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    recipient.save(output_path)
+
+    return {"grafted": grafted, "skipped": skipped}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--recipient", required=True)
+    ap.add_argument("--donor", required=True)
+    ap.add_argument("--output", required=True)
+    args = ap.parse_args()
+
+    result = graft(args.recipient, args.donor, args.output)
+    print(f"Grafted {len(result['grafted'])} Vedic codepoints into {args.output}")
+    above = sum(1 for *_, dy in result['grafted'] if dy)
+    print(f"  Above-marks Y-aligned to bbox-bottom={TARGET_ABOVE_BOTTOM_Y}: {above}")
+    print(f"  Marks centered to X={TARGET_MARK_CENTER_X}: {len(result['grafted'])}")
+    if result['skipped']:
+        print(f"  Skipped: {len(result['skipped'])}")
+        for cp, reason in result['skipped']:
+            print(f"    U+{cp:04X}: {reason}")
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/BalooTammudu2-Telugu/vedic-build/prepare_webfont.py
+++ b/BalooTammudu2-Telugu/vedic-build/prepare_webfont.py
@@ -1,0 +1,137 @@
+"""
+Rename the patched TTFs to a distinct family and emit WOFF2 web fonts.
+
+Renames the family from "Baloo Tammudu 2" to a derivative name so the web
+release does not collide with the official Baloo Tammudu 2 shipped by
+EkType/Google Fonts. Updates all relevant name-table records, the version
+string, the OS/2 typographic family, and the PostScript name. Preserves
+the OFL copyright/license records and the Noto donor attribution added in
+the earlier graft step.
+
+Also compresses each renamed TTF into WOFF2 for web use.
+
+Usage:
+    python prepare_webfont.py --input-dir . --output-dir webfont/
+"""
+from __future__ import annotations
+import argparse
+import os
+import sys
+from datetime import date
+from fontTools.ttLib import TTFont
+from fontTools.ttLib.woff2 import compress
+
+# Derivative family name. Kept close to the original so users understand
+# the lineage, but distinct enough to avoid identity collision with the
+# official Baloo Tammudu 2. This is the derivative name; the official
+# Baloo Tammudu 2 fonts remain the authoritative source.
+NEW_FAMILY = "Baloo Tammudu 2 Vedic"
+NEW_PS_FAMILY = "BalooTammudu2Vedic"
+NEW_VERSION_MAJOR = 1
+NEW_VERSION_MINOR = 0
+NEW_VERSION_NOTE = (
+    "1.000; Vedic derivative prototype; grafts U+0951-U+0954 and "
+    "U+1CD0-U+1CFF from Noto Sans Devanagari (OFL)"
+)
+
+
+# Name IDs the OFL requires to preserve verbatim
+OFL_PRESERVED_IDS = {0, 7, 13, 14}
+
+
+def set_name(name_table, name_id, value, platforms=None):
+    """Set a name-table record across all matching platform/encoding/lang
+    triples that already exist, so we don't leave stale ID copies behind."""
+    if platforms is None:
+        platforms = [
+            (3, 1, 0x409),   # Windows / Unicode BMP / en-US
+            (1, 0, 0),       # Mac / Roman / English (legacy)
+        ]
+    for platformID, platEncID, langID in platforms:
+        name_table.setName(value, name_id, platformID, platEncID, langID)
+
+
+def rename_font(font, weight_name):
+    """Rewrite the name table to the derivative family/subfamily."""
+    name = font['name']
+
+    # Basic 4-name family. When the subfamily is one of the "RIBBI" four
+    # (Regular / Italic / Bold / Bold Italic) OT recommends using IDs 1/2
+    # for those and omitting 16/17. Since we have 5 weights, we use the
+    # typographic family (16) + typographic subfamily (17) for the full
+    # family so applications see all five, and put a RIBBI-friendly pair in
+    # 1/2 that maps ExtraBold/Medium/SemiBold into "Regular" style.
+    if weight_name == "Regular":
+        set_name(name, 1, NEW_FAMILY)
+        set_name(name, 2, "Regular")
+    elif weight_name == "Bold":
+        set_name(name, 1, NEW_FAMILY)
+        set_name(name, 2, "Bold")
+    else:
+        # For Medium, SemiBold, ExtraBold: the "traditional" 4-family view
+        # collapses them into a subfamily under a family suffixed with the
+        # weight; the typographic pair (16/17) keeps them together.
+        set_name(name, 1, f"{NEW_FAMILY} {weight_name}")
+        set_name(name, 2, "Regular")
+
+    # Typographic family/subfamily (used by modern apps to keep all 5
+    # weights under one family).
+    set_name(name, 16, NEW_FAMILY)
+    set_name(name, 17, weight_name)
+
+    # Full name (ID 4) and PostScript name (ID 6).
+    set_name(name, 4, f"{NEW_FAMILY} {weight_name}")
+    set_name(name, 6, f"{NEW_PS_FAMILY}-{weight_name}")
+
+    # Unique identifier (ID 3). Convention: "vendor; PS-name; version".
+    set_name(name, 3, f"revurpk; {NEW_PS_FAMILY}-{weight_name}; {NEW_VERSION_MAJOR}.{NEW_VERSION_MINOR:03d}")
+
+    # Version string (ID 5).
+    set_name(name, 5, f"Version {NEW_VERSION_NOTE}")
+
+    # head.fontRevision matches the version.
+    font['head'].fontRevision = NEW_VERSION_MAJOR + NEW_VERSION_MINOR / 1000
+
+    # OS/2 achVendID: neutral 4-char tag for the derivative build. Vendor
+    # tags are informal; "PRVR" identifies revurpk's derivative.
+    font['OS/2'].achVendID = "PRVR"
+
+
+def rename_and_save(input_path, output_ttf_path, weight_name):
+    font = TTFont(input_path)
+    rename_font(font, weight_name)
+    os.makedirs(os.path.dirname(output_ttf_path) or '.', exist_ok=True)
+    font.save(output_ttf_path)
+
+
+def make_woff2(ttf_path, woff2_path):
+    compress(ttf_path, woff2_path)
+
+
+def process_weight(input_dir, output_dir, weight):
+    src = os.path.join(input_dir, f"BalooTammudu2-{weight}.ttf")
+    out_ttf = os.path.join(output_dir, f"{NEW_PS_FAMILY}-{weight}.ttf")
+    out_woff2 = os.path.join(output_dir, f"{NEW_PS_FAMILY}-{weight}.woff2")
+    rename_and_save(src, out_ttf, weight)
+    make_woff2(out_ttf, out_woff2)
+    return out_ttf, out_woff2
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input-dir", required=True,
+                    help="Directory with BalooTammudu2-*.ttf (patched, anchored)")
+    ap.add_argument("--output-dir", required=True,
+                    help="Where to write renamed TTFs and WOFF2s")
+    args = ap.parse_args()
+
+    weights = ["Regular", "Medium", "SemiBold", "Bold", "ExtraBold"]
+    for w in weights:
+        ttf, woff2 = process_weight(args.input_dir, args.output_dir, w)
+        ttf_kb = os.path.getsize(ttf) // 1024
+        woff2_kb = os.path.getsize(woff2) // 1024
+        print(f"  {w:10s} TTF {ttf_kb:5d}KB  WOFF2 {woff2_kb:5d}KB")
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/BalooTammudu2-Telugu/vedic-build/webfont/README.md
+++ b/BalooTammudu2-Telugu/vedic-build/webfont/README.md
@@ -1,0 +1,51 @@
+# Baloo Tammudu 2 Vedic — web font distribution
+
+Web-ready derivative of Baloo Tammudu 2 that adds rendering for the
+Unicode Vedic Extensions block (U+1CD0–U+1CFF) and the four Devanagari
+Vedic accents (U+0951–U+0954).
+
+## Contents
+
+| File | Purpose |
+|---|---|
+| `BalooTammudu2Vedic-{Weight}.woff2` | Web font (preferred) — one per weight. ~160KB each. |
+| `BalooTammudu2Vedic-{Weight}.ttf` | TrueType fallback for `format('truetype')` clients. |
+| `styles.css` | `@font-face` rules for all five weights with `font-display: swap` and `unicode-range` filtered to Latin + Telugu + Vedic. |
+| `demo.html` | Visual smoke test — renders sample Vedic Sanskrit strings across all weights. |
+
+Weights: Regular (400), Medium (500), SemiBold (600), Bold (700), ExtraBold (800).
+
+## Usage
+
+Copy `styles.css` and the `*.woff2` files to your site (they must live in the
+same directory unless you edit the `url()` paths in `styles.css`), then:
+
+```html
+<link rel="stylesheet" href="/fonts/baloo-tammudu-2-vedic/styles.css">
+<style>
+  body { font-family: 'Baloo Tammudu 2 Vedic', system-ui, sans-serif; }
+</style>
+```
+
+Ship with an aggressive cache header — the filenames are stable per build:
+
+```
+Cache-Control: public, max-age=31536000, immutable
+```
+
+## License
+
+Licensed under the SIL Open Font License, Version 1.1. See the top-level
+[`OFL.txt`](../../../OFL.txt) for the full text and the required attribution
+for the donor outlines (Noto Sans Devanagari, © 2022 The Noto Project
+Authors).
+
+## Not an official release
+
+This is a **prototype** derivative built by grafting outlines from Noto
+Sans Devanagari into the released Baloo Tammudu 2 TTX. The `.vfb` sources
+in `../Regular/VFB/` etc. are unchanged. Anyone can rebuild it from the
+pipeline documented in [`../README.md`](../README.md).
+
+For a proper native implementation, follow the tracking issue at
+<https://github.com/EkType/Baloo2/issues>.

--- a/BalooTammudu2-Telugu/vedic-build/webfont/demo.html
+++ b/BalooTammudu2-Telugu/vedic-build/webfont/demo.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="te">
+<head>
+<meta charset="utf-8">
+<title>Baloo Tammudu 2 Vedic — demo</title>
+<link rel="stylesheet" href="styles.css">
+<style>
+  :root {
+    color-scheme: light dark;
+    --fg: #111;
+    --muted: #666;
+    --border: #ddd;
+    --bg: #fff;
+    --sample-bg: #fafafa;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root { --fg: #eee; --muted: #999; --border: #333; --bg: #111; --sample-bg: #1a1a1a; }
+  }
+  body {
+    font-family: 'Baloo Tammudu 2 Vedic', system-ui, sans-serif;
+    color: var(--fg);
+    background: var(--bg);
+    max-width: 900px;
+    margin: 2rem auto;
+    padding: 0 1.5rem 4rem;
+    line-height: 1.5;
+  }
+  header { border-bottom: 1px solid var(--border); padding-bottom: 1rem; margin-bottom: 2rem; }
+  h1 { font-weight: 800; margin: 0 0 .25rem; font-size: 2rem; }
+  header p { color: var(--muted); margin: 0; font-size: .95rem; }
+  section { margin: 2rem 0; }
+  h2 { font-weight: 700; font-size: 1.25rem; margin: 0 0 .5rem; }
+  h2 small { color: var(--muted); font-weight: 500; font-size: .85rem; margin-left: .5rem; }
+  .sample {
+    background: var(--sample-bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 1rem 1.25rem;
+    margin: .5rem 0;
+  }
+  .te { font-size: 2rem; line-height: 1.3; }
+  .label { color: var(--muted); font-size: .85rem; margin-top: .25rem; }
+  table { border-collapse: collapse; width: 100%; margin-top: .5rem; }
+  td, th { text-align: left; padding: .35rem .75rem; border-bottom: 1px solid var(--border); }
+  th { color: var(--muted); font-weight: 500; font-size: .85rem; }
+  .weight-strip { display: flex; flex-wrap: wrap; gap: 1.5rem; }
+  .weight-strip > div { min-width: 130px; }
+  .weight-strip .te { font-size: 2.75rem; margin: 0; }
+  .w400 { font-weight: 400; }
+  .w500 { font-weight: 500; }
+  .w600 { font-weight: 600; }
+  .w700 { font-weight: 700; }
+  .w800 { font-weight: 800; }
+  code { font-family: 'SF Mono', Consolas, monospace; font-size: .9em; background: var(--sample-bg); padding: .1em .35em; border-radius: 3px; }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>Baloo Tammudu 2 Vedic</h1>
+  <p>Prototype web font. Grafts Vedic marks (U+0951–U+0954 and U+1CD0–U+1CFF)
+     into Baloo Tammudu 2 for Telugu-script Sanskrit typesetting.</p>
+</header>
+
+<section>
+  <h2>Weights</h2>
+  <div class="weight-strip">
+    <div><div class="te w400">నమః</div><div class="label">400 Regular</div></div>
+    <div><div class="te w500">నమః</div><div class="label">500 Medium</div></div>
+    <div><div class="te w600">నమః</div><div class="label">600 SemiBold</div></div>
+    <div><div class="te w700">నమః</div><div class="label">700 Bold</div></div>
+    <div><div class="te w800">నమః</div><div class="label">800 ExtraBold</div></div>
+  </div>
+</section>
+
+<section>
+  <h2>Vedic accents on Telugu bases <small>the reason this font exists</small></h2>
+
+  <div class="sample">
+    <div class="te">నమో నమో॑ నమో᳚ నమః</div>
+    <div class="label">Plain / U+0951 udatta / U+1CDA double svarita / visarga</div>
+  </div>
+
+  <div class="sample">
+    <div class="te">క క॑ క᳚ కః</div>
+    <div class="label">Standalone consonant + various accents</div>
+  </div>
+
+  <div class="sample">
+    <div class="te">అగ్నిమీళే॑ పురో॑హితం</div>
+    <div class="label">Ṛgveda 1.1.1 opening, Telugu script</div>
+  </div>
+
+  <div class="sample">
+    <div class="te">సర్వే॑ భవన్తు॑ సుఖి॒నః</div>
+    <div class="label">Universal peace invocation (svara-marked)</div>
+  </div>
+
+  <div class="sample">
+    <div class="te">ఓం భూర్భువః᳚ స్వః</div>
+    <div class="label">Bhūrbhuvaḥ svaḥ with double svarita</div>
+  </div>
+</section>
+
+<section>
+  <h2>Coverage by codepoint <small>45 of 48 in Vedic Extensions + 4 Devanagari Vedic accents</small></h2>
+  <table>
+    <thead><tr><th>Range</th><th>Sample</th><th>Notes</th></tr></thead>
+    <tbody>
+      <tr><td><code>U+0951</code></td><td class="te">క॑</td><td>Devanagari udatta</td></tr>
+      <tr><td><code>U+0952</code></td><td class="te">క॒</td><td>Devanagari anudatta (below-mark)</td></tr>
+      <tr><td><code>U+0953</code></td><td class="te">క॓</td><td>Devanagari grave</td></tr>
+      <tr><td><code>U+0954</code></td><td class="te">క॔</td><td>Devanagari acute</td></tr>
+      <tr><td><code>U+1CD0</code></td><td class="te">క᳐</td><td>Vedic karshana</td></tr>
+      <tr><td><code>U+1CDA</code></td><td class="te">క᳚</td><td>Vedic double svarita</td></tr>
+      <tr><td><code>U+1CDD</code></td><td class="te">క᳝</td><td>Vedic dot below</td></tr>
+      <tr><td><code>U+1CF4</code></td><td class="te">క᳴</td><td>Vedic candra above</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section>
+  <h2>Base Telugu <small>unchanged from upstream Baloo Tammudu 2</small></h2>
+  <div class="sample">
+    <div class="te">తెలుగు అక్షరాలు: క ఖ గ ఘ ఙ చ ఛ జ ఝ ఞ ట ఠ డ ఢ ణ త థ ద ధ న ప ఫ బ భ మ య ర ల వ శ ష స హ ళ క్ష ఱ</div>
+  </div>
+  <div class="sample">
+    <div class="te">అ ఆ ఇ ఈ ఉ ఊ ఋ ౠ ఎ ఏ ఐ ఒ ఓ ఔ</div>
+  </div>
+</section>
+
+</body>
+</html>

--- a/BalooTammudu2-Telugu/vedic-build/webfont/styles.css
+++ b/BalooTammudu2-Telugu/vedic-build/webfont/styles.css
@@ -1,0 +1,96 @@
+/*
+ * Baloo Tammudu 2 Vedic - web font stylesheet
+ *
+ * A prototype derivative of Baloo Tammudu 2 (Ek Type, OFL) that adds
+ * rendering for the Unicode Vedic Extensions block (U+1CD0-U+1CFF) plus
+ * the Devanagari-block Vedic accents (U+0951-U+0954). The Vedic glyph
+ * outlines are grafted from Noto Sans Devanagari (OFL) and positioned via
+ * new abvm/blwm/mkmk GPOS lookups.
+ *
+ * Not an official EkType/Google Fonts release.
+ *
+ * Hosting note: put the .woff2 files next to this stylesheet, or update the
+ * `url()` paths below to match your CDN layout. Ship with `Cache-Control:
+ * public, max-age=31536000, immutable` since the filenames are versioned by
+ * content.
+ */
+
+@font-face {
+  font-family: 'Baloo Tammudu 2 Vedic';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('BalooTammudu2Vedic-Regular.woff2') format('woff2'),
+       url('BalooTammudu2Vedic-Regular.ttf') format('truetype');
+  unicode-range:
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+    U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,
+    U+2193, U+2212, U+2215, U+FEFF, U+FFFD,
+    U+0951-0954,
+    U+0C00-0C7F,
+    U+1CD0-1CFF;
+}
+
+@font-face {
+  font-family: 'Baloo Tammudu 2 Vedic';
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url('BalooTammudu2Vedic-Medium.woff2') format('woff2'),
+       url('BalooTammudu2Vedic-Medium.ttf') format('truetype');
+  unicode-range:
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+    U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,
+    U+2193, U+2212, U+2215, U+FEFF, U+FFFD,
+    U+0951-0954,
+    U+0C00-0C7F,
+    U+1CD0-1CFF;
+}
+
+@font-face {
+  font-family: 'Baloo Tammudu 2 Vedic';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url('BalooTammudu2Vedic-SemiBold.woff2') format('woff2'),
+       url('BalooTammudu2Vedic-SemiBold.ttf') format('truetype');
+  unicode-range:
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+    U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,
+    U+2193, U+2212, U+2215, U+FEFF, U+FFFD,
+    U+0951-0954,
+    U+0C00-0C7F,
+    U+1CD0-1CFF;
+}
+
+@font-face {
+  font-family: 'Baloo Tammudu 2 Vedic';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url('BalooTammudu2Vedic-Bold.woff2') format('woff2'),
+       url('BalooTammudu2Vedic-Bold.ttf') format('truetype');
+  unicode-range:
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+    U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,
+    U+2193, U+2212, U+2215, U+FEFF, U+FFFD,
+    U+0951-0954,
+    U+0C00-0C7F,
+    U+1CD0-1CFF;
+}
+
+@font-face {
+  font-family: 'Baloo Tammudu 2 Vedic';
+  font-style: normal;
+  font-weight: 800;
+  font-display: swap;
+  src: url('BalooTammudu2Vedic-ExtraBold.woff2') format('woff2'),
+       url('BalooTammudu2Vedic-ExtraBold.ttf') format('truetype');
+  unicode-range:
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+    U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,
+    U+2193, U+2212, U+2215, U+FEFF, U+FFFD,
+    U+0951-0954,
+    U+0C00-0C7F,
+    U+1CD0-1CFF;
+}

--- a/OFL.txt
+++ b/OFL.txt
@@ -1,5 +1,13 @@
 ﻿Copyright (c) 2019 Ek Type (www.ektype.in)
 
+Portions of Baloo Tammudu 2 covering Vedic accent marks - the Unicode Vedic
+Extensions block (U+1CD0-U+1CFF) and the Devanagari-block Vedic accents
+(U+0951-U+0954) - are derived from Noto Sans Devanagari:
+Copyright 2022 The Noto Project Authors (https://github.com/notofonts/devanagari)
+Licensed under the SIL Open Font License, Version 1.1.
+"Noto" is a trademark of Google Inc. and is not used in any Baloo Tammudu 2
+font name; the trademark is acknowledged here per OFL Section 4.
+
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:
 http://scripts.sil.org/OFL


### PR DESCRIPTION
## This is a prototype for review generated using Claude Code, not a merge-ready implementation. The TODO list in the README captures what's still needed.

Adds rendering support for Vedic accent marks to all five weights of Baloo Tammudu 2 by grafting outlines from Noto Sans Devanagari (OFL) into the released TTX artefacts, then wiring proper OpenType layout.

Codepoints covered (45 total):
  - U+0951-U+0954  Devanagari Vedic accents (udatta, anudatta, grave, acute) - widely used in Telugu Sanskrit prosody
  - U+1CD0-U+1CFF  Unicode Vedic Extensions block (41/48 assigned; gaps are Unicode 12/13 additions or unassigned codepoints that the donor does not have either)

Implementation
--------------
vedic-build/graft_vedic.py
  - Flattens donor composites via DecomposingRecordingPen.
  - Adapts geometry: above-marks have bbox-bottom aligned to Y=600 (Baloos existing mark band); all marks centered at X=-300 so they land over a typical Telugu base under static positioning.
  - Sets zero advance width, GDEF class 3 (mark), and adds cmap entries on the Windows BMP subtable.

vedic-build/add_vedic_gpos.py
  - Adds a new GPOS lookup (type 4, MarkBasePos) with anchors on 74 Telugu consonants (top-center at ymax + 220) and 27 Vedic above-marks (bottom-center at ymin).
  - Excludes above-base matras and halant from the base coverage so the mark attaches to the consonant directly rather than to a matras off-center bbox.
  - Registers a new abvm feature on the tel2 and telu scripts.

Build pipeline
--------------
  TTX -> intermediate TTF (via fontTools.ttx)
       -> patched TTF      (via graft_vedic.py)
       -> patched TTF      (via add_vedic_gpos.py adds GPOS)

The five patched TTFs land in BalooTammudu2-Telugu/vedic-build/ and are gitignored (covered by repo-wide *.ttf rule); regenerate with the pipeline documented in vedic-build/README.md.

Scope and caveats
-----------------
This is a non-authoritative prototype. The .vfb sources in BalooTammudu2-Telugu/*/VFB/ are unchanged. A feature request tracking the proper work has been filed at github.com/EkType/Baloo2/issues.

Limitations of the graft:
  - Style mismatch: Notos stroke contrast differs from Baloos.
  - Only above-marks get GPOS anchors; below-marks (U+0952 anudatta and a few in Vedic Extensions) rely on static positioning.
  - Tall above-base matras like matraIi come within ~80 units of the marks; tune BASE_ANCHOR_Y_GAP in add_vedic_gpos.py for more clearance.

TODO for the proper fix (full list in vedic-build/README.md):
  - Draw native Vedic glyphs in FontLab matched to Baloos display style, in all five weights. This is the blocker.
  - Add GlyphOrderAndAliasDB and GDEF entries for the new glyphs.
  - Design real GPOS anchors (above and below) in the .vfb sources rather than the heuristic this prototype uses.
  - Handle above-base matras via mkmk anchors or contextual GPOS instead of the current exclude-from-coverage workaround.
  - Register abvm/blwm features in the source feature tables so the fix survives the next VFB->TTF rebuild (this prototype patches GPOS at the TTF level only).
  - Cover the seven gaps the donor lacks (U+1CF7, U+1CFA).
  - Visual QA across a Vedic test corpus.
  - Remove vedic-build/ once proper sources ship.

Files changed
-------------
  OFL.txt                                       Noto attribution per OFL S4
  BalooTammudu2-Telugu/vedic-build/.gitignore   Skip donor tree, ephemera
  BalooTammudu2-Telugu/vedic-build/README.md    Pipeline, caveats, TODO
  BalooTammudu2-Telugu/vedic-build/graft_vedic.py
  BalooTammudu2-Telugu/vedic-build/add_vedic_gpos.py